### PR TITLE
Enhance validation after AI categorization

### DIFF
--- a/Categorization.js
+++ b/Categorization.js
@@ -642,6 +642,10 @@ function columnLetterToIndex(col) {
   return index;
 }
 
+function normalizeTitle(text) {
+  return String(text).toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 
 /**
  * Creates a custom menu when the Google Sheet is opened.
@@ -848,7 +852,7 @@ function categorizeProductsWithFixedList(maxRowsToProcess) {
 
     if (categoriesForThisPrompt.length === 0) {
         Logger.log("CRITICAL: categoriesForThisPrompt is empty for product: " + title + " even after fallbacks. Skipping API call, marking for review.");
-        resultsToWrite.push([i, "NEEDS_MANUAL_REVIEW_NO_CATEGORIES_SENT"]);
+        resultsToWrite.push({row: i, output: "NEEDS_MANUAL_REVIEW_NO_CATEGORIES_SENT", actual: "", normalized: normalizeTitle(title)});
         continue;
     }
 
@@ -867,9 +871,11 @@ function categorizeProductsWithFixedList(maxRowsToProcess) {
     Product Title: "\${title}"
     Product Description: "\${description}"
 
-    Think carefully, then reply ONLY with the chosen category:`;
+    Think carefully, then reply ONLY with the chosen category followed by a pipe and a confidence rating of High, Medium, or Low.
+    Example: Pro Audio > Mixers | High`;
 
-    let chosenCategory = "NEEDS_MANUAL_REVIEW_API_ISSUE"; 
+    let chosenCategory = "NEEDS_MANUAL_REVIEW_API_ISSUE";
+    let validatedCategory = "";
     let attempts = 0;
 
     while (attempts < MAX_API_RETRIES) {
@@ -893,18 +899,37 @@ function categorizeProductsWithFixedList(maxRowsToProcess) {
 
         if (responseCode === 200) {
           const jsonResponse = JSON.parse(responseText);
-          let extractedCategory = jsonResponse.choices && jsonResponse.choices[0] && jsonResponse.choices[0].message && jsonResponse.choices[0].message.content
-                                  ? jsonResponse.choices[0].message.content.trim()
-                                  : "";
-          
+          let rawText = jsonResponse.choices && jsonResponse.choices[0] && jsonResponse.choices[0].message && jsonResponse.choices[0].message.content
+                               ? jsonResponse.choices[0].message.content.trim()
+                               : "";
+
+          let extractedCategory = rawText;
+          let confidence = "";
+          const match = rawText.match(/^(.*?)(?:\s*\|\s*(High|Medium|Low))?$/i);
+          if (match) {
+            extractedCategory = match[1].trim();
+            confidence = match[2] ? match[2].trim().toUpperCase() : "";
+          }
+
           const lowerCaseAllowedCategories = categoriesForThisPrompt.map(cat => cat.toLowerCase());
+          
           if (extractedCategory && lowerCaseAllowedCategories.includes(extractedCategory.toLowerCase())) {
-            chosenCategory = categoriesForThisPrompt.find(cat => cat.toLowerCase() === extractedCategory.toLowerCase()) || extractedCategory;
+            validatedCategory = categoriesForThisPrompt.find(cat => cat.toLowerCase() === extractedCategory.toLowerCase()) || extractedCategory;
           } else {
             Logger.log(`CRITICAL AI DEVIATION: AI returned category "${extractedCategory}" which is not in the (filtered) allowed list for title: "${title}". Filtered list had ${categoriesForThisPrompt.length} items. First item was: "${categoriesForThisPrompt.length > 0 ? categoriesForThisPrompt[0] : 'EMPTY_FILTERED_LIST'}". Assigning first from filtered list as fallback.`);
-            chosenCategory = categoriesForThisPrompt.length > 0 ? categoriesForThisPrompt[0] : "NEEDS_MANUAL_REVIEW_AI_INVALID_CHOICE";
+            validatedCategory = categoriesForThisPrompt.length > 0 ? categoriesForThisPrompt[0] : "NEEDS_MANUAL_REVIEW_AI_INVALID_CHOICE";
           }
-          break; 
+
+          const vendorPrefixes = VENDOR_SPECIFIC_CATEGORY_PREFIXES[vendor] || VENDOR_SPECIFIC_CATEGORY_PREFIXES[Object.keys(VENDOR_SPECIFIC_CATEGORY_PREFIXES).find(v => vendor.toLowerCase().includes(v.toLowerCase()))];
+          if (vendorPrefixes && !vendorPrefixes.some(p => validatedCategory.startsWith(p))) {
+            chosenCategory = `AI_LOGIC_CONFLICT_VENDOR_PREFIX: ${validatedCategory}`;
+          } else if (confidence !== "HIGH") {
+            chosenCategory = `NEEDS_MANUAL_REVIEW_CONFIDENCE_${confidence || 'MISSING'}: ${validatedCategory}`;
+          } else {
+            chosenCategory = validatedCategory;
+          }
+
+          break;
 
         } else if (responseCode === 429) {
           attempts++;
@@ -940,12 +965,29 @@ function categorizeProductsWithFixedList(maxRowsToProcess) {
         break; 
       }
     }
-    resultsToWrite.push([i, chosenCategory]);
+    resultsToWrite.push({row: i, output: chosenCategory, actual: validatedCategory || chosenCategory, normalized: normalizeTitle(title)});
   }
+
+  // Consistency check for nearly identical titles
+  const dupMap = {};
+  resultsToWrite.forEach(item => {
+    const key = item.normalized;
+    if (!dupMap[key]) {
+      dupMap[key] = {category: item.actual, refs: [item]};
+    } else {
+      if (dupMap[key].category !== item.actual) {
+        dupMap[key].refs.forEach(r => { r.output = 'AI_LOGIC_CONFLICT_DUPLICATE'; });
+        item.output = 'AI_LOGIC_CONFLICT_DUPLICATE';
+        dupMap[key].refs.push(item);
+      } else {
+        dupMap[key].refs.push(item);
+      }
+    }
+  });
 
   if (resultsToWrite.length > 0) {
     resultsToWrite.forEach(function(item) {
-      outputRange.getCell(item[0] + 1, 1).setValue(item[1]);
+      outputRange.getCell(item.row + 1, 1).setValue(item.output);
     });
     ui.alert(`Product categorization complete! ${processedCount} products were processed/re-processed in this run.`);
   } else {

--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ If the `Shopify_Categories` sheet is missing or empty, the script falls back to 
 Vendor‑specific prefixes and keyword mappings used to filter the category list can be edited in the `VENDOR_SPECIFIC_CATEGORY_PREFIXES` and `KEYWORD_TO_CATEGORY_GROUP_MAPPINGS` objects inside `Categorization.js`. Adjust these arrays to influence how categories are suggested for your products.
 The `BATCH_SIZE` constant controls how many rows are processed when running the batch command.
 
+## Post-Processing Validation
+
+Each categorization response must include a confidence level (High, Medium, or Low). Results that are not High are automatically flagged for manual review. The script also checks that vendor-specific categories match the configured `VENDOR_SPECIFIC_CATEGORY_PREFIXES`. If a mismatch occurs, the output is marked with an `AI_LOGIC_CONFLICT` error. Finally, nearly identical product titles categorized differently in the same run are flagged as duplicates for review.
+


### PR DESCRIPTION
## Summary
- require the AI to return a confidence level alongside the chosen category
- parse the confidence score and flag non-`High` results for manual review
- verify vendor-specific category prefixes to catch logic conflicts
- detect duplicates by normalizing product titles during post-processing
- document new validation behavior

## Testing
- `node --check Categorization.js`

------
https://chatgpt.com/codex/tasks/task_e_68421f667d808326ab0082654750c83a